### PR TITLE
Task 1 - log security breach fix

### DIFF
--- a/Python/Flask_Book_Library/project/customers/models.py
+++ b/Python/Flask_Book_Library/project/customers/models.py
@@ -1,5 +1,8 @@
 from project import db, app
 
+def hide_confidential(data:str) -> str:
+    str_len:int = len(data)
+    return '*'*str_len
 
 # Customer model
 class Customer(db.Model):
@@ -22,7 +25,7 @@ class Customer(db.Model):
         print("Getting: " + str(self),flush=True)
 
     def __repr__(self):
-        return f"Customer(ID: {self.id}, Name: {self.name}, City: {self.city}, Age: {self.age}, Pesel: {self.pesel}, Street: {self.street}, AppNo: {self.appNo})"
+        return f"Customer(ID: {self.id}, Name: {self.name}, City: {self.city}, Age: {self.age}, Pesel: {hide_confidential(self.pesel)}, Street: {hide_confidential(self.street)}, AppNo: {hide_confidential(self.appNo)})"
 
 
 with app.app_context():

--- a/Python/Flask_Book_Library/project/customers/models.py
+++ b/Python/Flask_Book_Library/project/customers/models.py
@@ -1,8 +1,12 @@
 from project import db, app
+import random
 
-def hide_confidential(data:str) -> str:
+def hide_confidential(data:str, up_rand:int) -> str:
     str_len:int = len(data)
-    return '*'*str_len
+    if up_rand == 0:
+        return str_len * '*'
+    randomized_len = random.randrange(str_len, str_len + up_rand)
+    return '*'*randomized_len
 
 # Customer model
 class Customer(db.Model):
@@ -25,7 +29,7 @@ class Customer(db.Model):
         print("Getting: " + str(self),flush=True)
 
     def __repr__(self):
-        return f"Customer(ID: {self.id}, Name: {self.name}, City: {self.city}, Age: {self.age}, Pesel: {hide_confidential(self.pesel)}, Street: {hide_confidential(self.street)}, AppNo: {hide_confidential(self.appNo)})"
+        return f"Customer(ID: {self.id}, Name: {self.name}, City: {self.city}, Age: {self.age}, Pesel: {hide_confidential(self.pesel, 0)}, Street: {hide_confidential(self.street, 4)}, AppNo: {hide_confidential(self.appNo, 1)})"
 
 
 with app.app_context():

--- a/Python/Flask_Book_Library/project/customers/models.py
+++ b/Python/Flask_Book_Library/project/customers/models.py
@@ -29,7 +29,7 @@ class Customer(db.Model):
         print("Getting: " + str(self),flush=True)
 
     def __repr__(self):
-        return f"Customer(ID: {self.id}, Name: {self.name}, City: {self.city}, Age: {self.age}, Pesel: {hide_confidential(self.pesel, 0)}, Street: {hide_confidential(self.street, 4)}, AppNo: {hide_confidential(self.appNo, 1)})"
+        return f"Customer(ID: {self.id}, Name: {self.name}, City: {self.city}, Age: {self.age}, Pesel: {hide_confidential(self.pesel, 0)}, Street: {hide_confidential(self.street, 4)}, AppNo: {hide_confidential(self.appNo, 2)})"
 
 
 with app.app_context():


### PR DESCRIPTION
# Laboratorium 2 
## Zadanie 1
Przeklikaniu aplikacji udało się dostrzec i weryfikacji logów udało się dostrzec wyciek danych wrażliwych na wskutek dodana nowego klienta ('Add New Customer'). Na wskutek wycieku widać pełny adres zamieszkania klienta oraz jego PESEL:
![zad2](https://github.com/The0Jan/task2/assets/73556824/202548be-9d3b-41af-8300-d117883c106b)
 
W ramach załatania tego wycieku, informacje w rubrykach 'PESEL', 'Street', 'AppNo' pojawiające się w logach po utworzeniu nowego klienta, zostają zamienione ciągiem znaków o różnej długości składających się wyłącznie z '*'.
- dla 'PESEL' będzie on długości 'PESEL',
- dla 'Street' będzie on losowej długości w zakresie [dłg. 'Street', dłg. 'Street' + 4),
- dla 'AppNo' będzie on losowej długości w zakresie [dłg. 'AppNo', dłg. 'AppNo' + 2),
- 
![zad21](https://github.com/The0Jan/task2/assets/73556824/dbe9b2f5-ad0d-4678-8ee1-9f8432cc9245)

## Zadanie 2
Na wskutek wykorzystania aplikacji gitleaks udało się wykryć 4 wycieki.
![obraz](https://github.com/The0Jan/task2/assets/73556824/f05a399a-9bb7-43bf-9a33-e4da9a2ecf54)

Wycieki zawarte w raporcie gitleaks dotyczyły dwóch commitów:
1. commitu: de9d7b8cb63bd7ae741ec5c9e23891b71709bc28
![commit1](https://github.com/The0Jan/task2/assets/73556824/3ff50652-ab5c-448a-9994-1f22a68d10d7)

2. commitu: bc17b7ddc46f46fff175aed55d68e11bb48166cc (W tym commtcie gitleaks wykrył nawet trzy wycieki)
![commit4](https://github.com/The0Jan/task2/assets/73556824/cf3061d7-5b81-4a1b-b3ef-7e8eaa3eb521)
![commit3](https://github.com/The0Jan/task2/assets/73556824/cf9a9593-5202-41fc-88e8-c759698d8656)
![commit2](https://github.com/The0Jan/task2/assets/73556824/811e2187-e63c-4910-a23e-48d9c6e50492)

Po zweryfikowanie wyników można ocenić że trzy z z czterech wykrytych wycieków są jawnymi wyciekami kluczy prywatnych. Jeden zidentyfikowany wyciek jest powiązany z id klucza prywatnego. Niemniej jednak jest to nadal wyciek niechcianych danych z narzuconą wartością. Na wskutek tego nie mogę go zidentyfikować jako fałszywy pozytyw, a jako wyciek sekretów.

Propozycje poprawienia problemu:
- nie przechowywanie sekretów i kluczy w formie jawnej jako plików i zmiennych,
- natychmiastowe unieważnienie i wymieniana haseł, 
- dynamicznie generowanie haseł,
- modyfikacja historii repozytorium,
- wprowadzenie wtyczki po stronie programistów i osób zarządzających, która by sprawdzała wszystkie zmiany dodane do commit'u w celu wykrycia pojawienia się hardkodowanych haseł lub sekretów.

## Zadanie 3

### Wyniki uruchomienia weryfikacji pakietów 
![obraz](https://github.com/The0Jan/task2/assets/73556824/5224bf96-612e-44de-bd71-d15970fb004f)

### Analiza wyników

Na wskutek weryfikacji pakietów udało się wykryć jedną podatność. W pakiecie 'healpy'. Dotyczy ona wykorzystywania wersji 'libcurl' zawierającej podatności o wysokich skutkach. Po wyszukaniu po ID dodatkowych informacji, udało się ustalić, że chodzi o podatność [CVE-2023-38545](https://nvd.nist.gov/vuln/detail/CVE-2023-38545)

![obraz](https://github.com/The0Jan/task2/assets/73556824/9c295bc9-2f7b-4b4e-adac-2df65b7175e0)

### Opis i analiza podatności

Wykryta podatność należy do kategorii 'Zapisu poza granicami' (ang. [Out-of-Bounds Write](https://cwe.mitre.org/data/definitions/787.html)) . 

Podatność CVE-2023-38545 pojawia się w trakcie uścisku dłoni w połączeniu proxy SOCKS5. 
Protokół SOCKS5 ma dwa tryby rozwiązywania nazw. W jednym to klient rozwiązuje nazwę lokalnie i podsyła tylko cel jako już rozwiązany adres, a w drugim to proxy jest odpowiedzialne za rozwiązanie nazwy. Proxy jest ograniczone jedynie do 255 bajtów. Jeżeli, więc zostanie podana nazwa hosta przekraczająca 255 bajtów, curl przełącza się na lokalne rozpoznawanie nazwy, a podsyła tylko adres do proxy. Za to przełączenie się jest odpowiedzialna jedna lokalna zmienna która podczas powolnego uścisku na wskutek błędu może przyjąć złą wartość. 

Efektem jest, curl kopiujący zbyt dużą nazwę hosta do zbyt małego buffora ramki (ang. framebuffer). Na wskutek czego dochodzi do przepełnienia buffor na stercie (ang. heap buffer overflow) .

Po analizie w badanej aplikacji nie wykorzystujemy żadnych metod powiązanych z pakietem 'healpy', ani 'curl' lub 'libcurl'. Prawdopodobieństwo więc wykorzystania tej podatności jest bardzo niskie.

### Ocena zagrożenia

Mimo tego, że w obecnej wersji aplikacji nie korzystamy z pakietu 'healpy', 'curl' lub 'libcurl', nadal dobrze byłoby załatać tą podatność ze względu na jej wysoki poziom zagrożenia. W przypadku 'cURL' zalecana jest migracja do wersji 8.4.0, w której ta podatność została już załatana. Na nieszczęście pakiet 'healpy' nadal nie jest załatany i wciąż posiada tą podatność, nawet w swojej najnowszej wersji (jest wysyłany ze starszą wersją curl, która ma niezałataną podatność). W związku z tym nie jestem w stanie polecić żadnej innej wersji 'healpy'. Zalecone jest niekorzystanie tymczasowo z tego pakietu, tym bardziej iż obecnie nie jest on jeszcze wykorzystywany w naszym projekcie oraz usunięcie pakietu z pliku 'requirements.txt'.
